### PR TITLE
Fix: Ensure ingest.py loads .env file for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,9 @@ Execute the following command in your terminal.
 ```bash
 python ingest.py
 ```
-The `ingest.py` script processes PDF documents from the `data/` directory. During ingestion:
+The `ingest.py` script processes PDF documents from the `data/` directory. It also loads necessary configurations (like API keys for embedding models, LLMs for graph extraction, and Neo4j connection details) from the `.env` file, similar to `app.py`. Ensure your `.env` file is populated by referring to `.env.example`.
+
+During ingestion:
 1.  Text is extracted and split into manageable chunks.
 2.  These chunks are embedded and stored in ChromaDB for vector search.
 3.  Entities and relationships are extracted from the chunks using a Language Model and stored as a graph in Neo4j. This populates the knowledge graph used in the hybrid RAG process.

--- a/ingest.py
+++ b/ingest.py
@@ -7,6 +7,7 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_chroma import Chroma
 from langchain_core.prompts import ChatPromptTemplate # Added ChatPromptTemplate import
 from langchain_google_genai import ChatGoogleGenerativeAI # Added ChatGoogleGenerativeAI import
+from dotenv import load_dotenv
 from src.utils import get_embedding_model
 
 DATA_PATH = "data"
@@ -103,6 +104,11 @@ def log_processed_file(filename):
 
 def main():
     """Performs incremental ingestion of new PDF files into the ChromaDB vector store."""
+    load_dotenv()
+    if os.getenv("GOOGLE_API_KEY"):
+        print("Successfully loaded environment variables from .env file.")
+    else:
+        print("Info: .env file not found or key 'GOOGLE_API_KEY' is not set. Proceeding with environment variables.")
     print("--- Starting Incremental Ingestion Process ---")
     os.makedirs(DB_PATH, exist_ok=True)
 


### PR DESCRIPTION
The ingest.py script was not loading environment variables from the .env file when you ran it directly (e.g., `python ingest.py`). This could lead to missing configurations if they were not pre-set in the execution environment.

This commit addresses the issue by:
- Adding a call to `load_dotenv()` at the beginning of the `main()` function in `ingest.py`.
- Adding a print statement to inform you whether the .env file was successfully loaded or if it was not found/essential keys are missing.
- Updating `README.md` to clarify that `ingest.py` also uses the `.env` file for its configuration, consistent with `app.py`.