### PR TITLE
Fix: Corrected Cypher syntax for MERGE query in ingest.py

### DIFF
--- a/ingest.py
+++ b/ingest.py
@@ -67,7 +67,7 @@ def store_graph_data_in_neo4j(graph_data, driver):
                 print(f"Skipping entity due to missing name or type: {entity}", file=sys.stderr)
                 continue
             session.run(
-                "MERGE (e:Entity {{name: $name, type: $type}})",
+                "MERGE (e:Entity {name: $name, type: $type})",
                 name=entity["name"], type=entity["type"]
             )
         for rel in graph_data.get("relationships", []):


### PR DESCRIPTION
The MERGE statement for creating entities in Neo4j had an extra set of curly braces around the properties map. This caused a Neo.ClientError.Statement.SyntaxError.

This commit corrects the syntax from:
`MERGE (e:Entity {{name: $name, type: $type}})`
to:
`MERGE (e:Entity {name: $name, type: $type})`