### PR TITLE
Fix: Ensure asyncio event loop for Streamlit compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,15 @@
+import asyncio
+import sys # Required for the original startup checks, ensure it's there or added if not.
+
+try:
+    # Check if an event loop is already running
+    asyncio.get_running_loop()
+except RuntimeError:  # Specific error: 'There is no current event loop...'
+    # If no event loop is running, create a new one and set it as the current loop
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+# --- The rest of the app.py file follows ---
 import streamlit as st
 import json
 import os

--- a/test_app_initialization.py
+++ b/test_app_initialization.py
@@ -1,0 +1,33 @@
+import sys
+import os
+
+# Ensure 'src' is in the Python path to allow importing from app
+# This might be needed if 'app.py' does relative imports or expects a certain working directory
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+
+print("Attempting to import app and initialize graph...")
+try:
+    # Import the function that sets up the graph, which was causing issues
+    from app import get_graph # app.py should now have the asyncio fix
+
+    # Attempt to call the function that initializes the graph
+    # This is where the HuggingFace/torch components are initialized
+    graph = get_graph()
+
+    if graph:
+        print("SUCCESS: app.get_graph() executed and returned a graph object.")
+    else:
+        print("WARNING: app.get_graph() executed but returned None or a falsy value.")
+
+except RuntimeError as e:
+    if "no running event loop" in str(e):
+        print(f"FAILURE: Still encountered RuntimeError: {e}")
+    else:
+        print(f"Encountered an unexpected RuntimeError: {e}")
+except ImportError as e:
+    print(f"FAILURE: Could not import 'app' or 'get_graph': {e}")
+    print("This might indicate an issue with the test script's path setup or a problem in app.py itself.")
+except Exception as e:
+    print(f"FAILURE: An unexpected error occurred: {type(e).__name__}: {e}")
+
+print("Test script finished.")


### PR DESCRIPTION
Addresses a `RuntimeError: no running event loop` that occurred during Streamlit application startup. This error was likely caused by an interaction between Streamlit's event loop management and libraries like `torch` (used indirectly by HuggingFace sentence transformers) that also interact with asyncio.

The fix involves proactively setting up an asyncio event loop at the very beginning of `app.py`, before any other modules (including Streamlit itself or `torch`-dependent modules) are imported. This ensures that a valid event loop is always present, preventing the runtime error.

Testing confirmed that with this change, the application no longer raises the `RuntimeError: no running event loop` and proceeds with initialization until hitting unrelated environmental constraints (disk space for model downloads).