### PR TITLE
feat: Allow configuration of max concurrency for Gemini API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ ENTREZ_API_KEY="your_pasted_entrez_api_key_here"
 # Recommended: "gemini-2.5-pro" for best quality or "gemini-2.5-flash" for speed/cost.
 LLM_MODEL="gemini-2.5-flash-preview-05-20"
 
+# --- Pipeline Configuration ---
+MAX_CONCURRENCY=5
+
 # --- Neo4j Connection ---
 NEO4J_URI=bolt://localhost:7687
 NEO4J_USERNAME=neo4j

--- a/README.md
+++ b/README.md
@@ -149,7 +149,15 @@ cp .env.example .env
 ```
 
 **2. Edit the `.env` file:**
-Open the newly created `.env` file with a text editor and fill in your actual credentials for `GOOGLE_API_KEY`, `ENTREZ_EMAIL`, and `ENTREZ_API_KEY`. You can also change the `LLM_MODEL` if you wish. Remember to also set your `NEO4J_URI`, `NEO4J_USERNAME`, and `NEO4J_PASSWORD` if you are using Neo4j.
+Open the newly created `.env` file with a text editor and fill in your actual credentials and settings:
+-   `GOOGLE_API_KEY`: Your API key for Google Gemini.
+-   `ENTREZ_EMAIL`: Your email address for NCBI Entrez API (PubMed).
+-   `ENTREZ_API_KEY`: Your API key for NCBI Entrez API.
+-   `LLM_MODEL`: The specific Gemini model to use (e.g., "gemini-1.5-flash-latest"). Defaults to "gemini-1.5-flash-preview-05-20" if not set.
+-   `MAX_CONCURRENCY`: (Optional) The maximum number of concurrent requests the knowledge pipeline will make to the Gemini API when processing articles. Defaults to `5`. This helps manage API rate limits and resource usage.
+-   `NEO4J_URI`: The connection URI for your Neo4j instance (e.g., `bolt://localhost:7687` or `neo4j+s://your-aura-instance.databases.neo4j.io`).
+-   `NEO4J_USERNAME`: The username for your Neo4j database.
+-   `NEO4J_PASSWORD`: The password for your Neo4j database.
 
 ### 4. Knowledge Base Ingestion (Mandatory First Step)
 

--- a/knowledge_pipeline.py
+++ b/knowledge_pipeline.py
@@ -232,7 +232,9 @@ def main():
     
     batch_inputs = [{"article_text": article["text"]} for article in new_articles_to_process]
     # Limit concurrency to be kind to the API
-    batch_results = extraction_chain.batch(batch_inputs, {"max_concurrency": 5})
+    # Load MAX_CONCURRENCY from environment variable, default to 5
+    max_concurrency = int(os.getenv("MAX_CONCURRENCY", "5"))
+    batch_results = extraction_chain.batch(batch_inputs, {"max_concurrency": max_concurrency})
 
     for i, result_str in enumerate(batch_results):
         url = new_articles_to_process[i]["url"]


### PR DESCRIPTION
This change introduces a new environment variable `MAX_CONCURRENCY` to control the number of simultaneous queries made to the Gemini API in the `knowledge_pipeline.py` script.

The `MAX_CONCURRENCY` variable can be set in the `.env` file. If not set, it defaults to 5.

The `README.md` file has been updated to document this new configuration option.